### PR TITLE
Create a pruning run() method that ignores end-points inside a ROI

### DIFF
--- a/src/main/java/skeleton_analysis/AnalyzeSkeleton_.java
+++ b/src/main/java/skeleton_analysis/AnalyzeSkeleton_.java
@@ -376,7 +376,10 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 	 * @param origIP original input image
 	 * @param silent
 	 * @param verbose flag to display running information
-	 * @param roi points inside this region are spared from elimination when pruning end branches
+	 * @param roi points inside this region are spared from elimination when
+	 *            pruning end branches. ROI can be associated to a single image
+	 *            in the stack or all images as per {@link ij.gui.Roi#getPosition
+	 *            ij.gui.Roi.getPosition()}
 	 */
 	public SkeletonResult run(
 			int pruneIndex,
@@ -2532,10 +2535,12 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 	
 	/* -----------------------------------------------------------------------*/
 	/**
-	 * Check if the point is an end point.
+	 * Check if the point is an 'unprotected' end point.
 	 *
 	 * @param point actual point
-	 * @param roi Only points outside this region will have end-point status
+	 * @param roi Only points outside this ROI will have end-point status. ROI
+	 *            can be associated to a single image in the stack (or all) as
+	 *            per {@link ij.gui.Roi#getPosition ij.gui.Roi.getPosition()}
 	 * @return true if the point has end-point status
 	 */
 	private boolean isEndPoint(Point point, Roi roi)


### PR DESCRIPTION
I've been using AnalyzeSkeleton's ability to prune end-points to perform [Strahler analysis](http://fiji.sc/Strahler).
In short: In a [BAR script](https://github.com/tferr/Scripts/blob/master/Morphometry/Strahler_Analysis.bsh), we iteratively eliminate terminal branches while monitoring the remaining number of end-points after each pruning cycle. The problem is that this approach only works if the root is excluded from the iterative elimination. Right now [`pruneEndBranches()`](https://github.com/fiji/AnalyzeSkeleton/blob/master/src/main/java/skeleton_analysis/AnalyzeSkeleton_.java#L605) makes no exceptions for root end-point(s) (that will always get eliminated on a first pruning cycle). This is mentioned in somewhat more detail [here](https://github.com/tferr/Scripts/issues/4) and [here](http://fiji.sc/Strahler#Non-radial_arbors).

So I thought this could be addressed by allowing `pruneEndBranches` to ignore endpoints inside a ROI (if present). I know that since AnalyzeSkeleton is now a release version its API has to be stable. So this is what I thought in this commit:
- Use a new `isEndPoint()` method that checks if the end-point is inside a given ROI
- Create a new `run()` method that accepts an input ROI and uses the modified `isEndPoint()` alternative

As far as I can tell, this makes it only possible to access this _ROI-exception_ feature from the API, not from the GUI of AnalyzeSkeleton_ that would be unaware of ROIs.

What I don't know is if we should develop this idea further:
1. Should we assume the ROI is associated to a single [Z dimension](https://github.com/tferr/AnalyzeSkeleton/compare/fiji:master...tferr:protective-roi?expand=1#diff-cc87f09500c10bc96a67735e7fdff36bR2515), or leave as is and assume ROI is associated with all slices of the stack?
2. Should we impose constrains on the ROI type (e.g., only accept Area ROIs), or assume that scripts that will be calling the run method will take care of validating the ROI passed as argument?

What do you guys think (specially @iarganda, @mdoube)? Is this any useful?
