### PR TITLE
Adding the Point History for running average length and average color

### DIFF
--- a/src/java/test/skeleton_analysis/BasicTest.java
+++ b/src/java/test/skeleton_analysis/BasicTest.java
@@ -3,7 +3,8 @@ package skeleton_analysis;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
-
+import sc.fiji.analyzeSkeleton.*;
+//Hallo Ralf
 public class BasicTest {
 
 	/**

--- a/src/java/test/skeleton_analysis/BasicTest.java
+++ b/src/java/test/skeleton_analysis/BasicTest.java
@@ -3,8 +3,7 @@ package skeleton_analysis;
 import ij.IJ;
 import ij.ImageJ;
 import ij.ImagePlus;
-import sc.fiji.analyzeSkeleton.*;
-//Hallo Ralf
+
 public class BasicTest {
 
 	/**

--- a/src/main/java/sc/fiji/analyzeSkeleton/AnalyzeSkeleton_.java
+++ b/src/main/java/sc/fiji/analyzeSkeleton/AnalyzeSkeleton_.java
@@ -1,6 +1,10 @@
 package sc.fiji.analyzeSkeleton;
 
-import ij.*;
+import ij.IJ;
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.Prefs;
+import ij.WindowManager;
 import ij.gui.DialogListener;
 import ij.gui.GenericDialog;
 import ij.gui.Roi;
@@ -19,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
+import java.util.List;
 import java.util.ListIterator;
 
 /**
@@ -1381,7 +1386,7 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 			
 			final String[] extra_head = {"Branch", "Skeleton ID", 
 							"Branch length","V1 x", "V1 y",
-							"V1 z","V2 x","V2 y", "V2 z", "Euclidean distance"};
+							"V1 z","V2 x","V2 y", "V2 z", "Euclidean distance","running average length", "avg color (inner 3rd)", "avg color"};
 			
 	
 			// Edge comparator (by branch length)
@@ -1419,6 +1424,9 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 					extra_rt.addValue(extra_head[7], e.getV2().getPoints().get(0).y * this.imRef.getCalibration().pixelHeight);
 					extra_rt.addValue(extra_head[8], e.getV2().getPoints().get(0).z * this.imRef.getCalibration().pixelDepth);
 					extra_rt.addValue(extra_head[9], this.calculateDistance(e.getV1().getPoints().get(0), e.getV2().getPoints().get(0)));
+					extra_rt.addValue(extra_head[10], e.getLength_ra());
+					extra_rt.addValue(extra_head[11], e.getColor3rd());
+					extra_rt.addValue(extra_head[12], e.getColor());
 				}		
 											
 			}
@@ -1477,92 +1485,6 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 		return result;
 	}
 
-	// -----------------------------------------------------------------------
-	/**
-	 * Visit skeleton from end points and register measures.
-	 * 
-	 * @param taggedImage
-	 * 
-	 * @deprecated
-	 */
-	private void visitSkeleton(ImageStack taggedImage) 
-	{
-	
-		// length of branches
-		double branchLength = 0;		
-		int numberOfBranches = 0;
-		double maximumBranchLength = 0;
-		double averageBranchLength = 0;
-		Point initialPoint = null;
-		Point finalPoint = null;
-		
-	
-		// Visit branches starting at end points
-		for(int i = 0; i < this.totalNumberOfEndPoints; i++)
-		{			
-			Point endPointCoord = this.listOfEndPoints.get(i);
-					 
-			// visit branch until next junction or end point.
-			double length = visitBranch(endPointCoord);
-						
-			if(length == 0)						
-				continue;			
-			
-			// increase number of branches
-			numberOfBranches++;
-			branchLength += length;				
-			
-			// update maximum branch length
-			if(length > maximumBranchLength)
-			{
-				maximumBranchLength = length;
-				initialPoint = endPointCoord;
-				finalPoint = this.auxPoint;
-			}
-		}
-		
-	
-		// Now visit branches starting at junctions
-		for(int i = 0; i < this.totalNumberOfJunctionVoxels; i++)
-		{
-			Point junctionCoord = this.listOfJunctionVoxels.get(i);
-			
-			// Mark junction as visited
-			setVisited(junctionCoord, true);
-					
-			Point nextPoint = getNextUnvisitedVoxel(junctionCoord);
-			
-			while(nextPoint != null)
-			{
-				branchLength += calculateDistance(junctionCoord, nextPoint);								
-								
-				double length = visitBranch(nextPoint);
-				
-				branchLength += length;
-				
-				// Increase number of branches
-				if(length != 0)
-				{
-					numberOfBranches++;
-					// update maximum branch length
-					if(length > maximumBranchLength)
-					{
-						maximumBranchLength = length;
-						initialPoint = junctionCoord;
-						finalPoint = this.auxPoint;
-					}
-				}
-				
-				nextPoint = getNextUnvisitedVoxel(junctionCoord);
-			}					
-		}
-
-		// Average length
-		averageBranchLength = branchLength / numberOfBranches;
-		
-	} // end visitSkeleton
-	
-	
 	/* -----------------------------------------------------------------------*/
 	/**
 	 * Visit skeleton starting at end-points, junctions and slab of circular 
@@ -1630,7 +1552,12 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 			this.slabList = new ArrayList<Point>();
 					 
 			// Otherwise, visit branch until next junction or end point.
-			double length = visitBranch(endPointCoord, iTree);
+			double[] properties = visitBranch(endPointCoord, iTree);
+			double length = properties[0];
+			double color3rd = properties[1];
+			double color = properties[2];
+			double length_ra = properties[3];
+
 						
 			// If length is 0, it means the tree is formed by only one voxel.
 			if(length == 0)
@@ -1650,7 +1577,7 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 					if(debug)
 						IJ.log( "adding branch from " + v1.getPoints().get(0) + " to " + this.auxFinalVertex.getPoints().get(0) );
 					this.graph[iTree].addVertex(this.auxFinalVertex);
-					this.graph[iTree].addEdge(new Edge(v1, this.auxFinalVertex, this.slabList, length));
+					this.graph[iTree].addEdge(new Edge(v1, this.auxFinalVertex, this.slabList, length, color3rd, color, length_ra));
 					// increase number of branches
 					this.numberOfBranches[iTree]++;
 					
@@ -1692,7 +1619,7 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 			if(debug)
 				IJ.log("adding branch from " + v1.getPoints().get(0) + " to " + this.auxFinalVertex.getPoints().get(0) +  ", aux point = " + this.auxPoint);
 			this.graph[iTree].addVertex(this.auxFinalVertex);
-			this.graph[iTree].addEdge(new Edge(v1, this.auxFinalVertex, this.slabList, length));
+			this.graph[iTree].addEdge(new Edge(v1, this.auxFinalVertex, this.slabList, length, color3rd, color, length_ra));
 			
 			// increase number of branches
 			this.numberOfBranches[iTree]++;
@@ -1751,7 +1678,13 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 
 						// Visit branch
 						this.auxPoint = null;
-						length += visitBranch(nextPoint, iTree);
+						
+						double[] properties = visitBranch(nextPoint, iTree);
+						length += properties[0];
+						double color3rd = properties[1];
+						double color = properties[2];
+						double length_ra = properties[3];
+
 
 						// Increase total length of branches
 						branchLength += length;
@@ -1810,7 +1743,7 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 							// Add branch to graph
 							if(debug)
 								IJ.log("adding branch from " + initialVertex.getPoints().get(0) + " to " + this.auxFinalVertex.getPoints().get(0));							
-							this.graph[iTree].addEdge(new Edge(initialVertex, this.auxFinalVertex, this.slabList, length));												
+							this.graph[iTree].addEdge(new Edge(initialVertex, this.auxFinalVertex, this.slabList, length, color3rd, color, length_ra));												
 						}
 					}
 					else
@@ -1844,7 +1777,11 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 			this.numberOfSlabs[iTree]++;
 			
 			// visit branch until finding visited voxel.
-			final double length = visitBranch(startCoord, iTree);
+			double[] properties = visitBranch(startCoord, iTree);
+			final double length = properties[0];
+			double color3rd = properties[1];
+			double color = properties[2];
+			double length_ra = properties[3];
 						
 			if(length != 0)
 			{				
@@ -1860,7 +1797,7 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 			}
 			
 			// Create circular edge
-			this.graph[iTree].addEdge(new Edge(v1, v1, this.slabList, length));
+			this.graph[iTree].addEdge(new Edge(v1, v1, this.slabList, length, color3rd, color, length_ra));
 		}						
 
 		if(debug)
@@ -2176,12 +2113,20 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 	 * 
 	 * @param startingPoint starting coordinates
 	 * @param iTree tree index
-	 * @return branch length
+	 * @return branch length and color
 	 */
-	private double visitBranch(Point startingPoint, int iTree) 
+	private double[] visitBranch(Point startingPoint, int iTree) 
 	{
 		//IJ.log("startingPoint = (" + startingPoint.x + ", " + startingPoint.y + ", " + startingPoint.z + ")");
 		double length = 0;
+		double color = 0.0;
+		double color3rd = 0.0;
+		double length_ra = 0.0;
+		double[] ret = new double[4];
+		
+		List<Point> pointHistory= new ArrayList<Point>(0);
+		pointHistory.add(0,startingPoint);
+		
 		
 		// mark starting point as visited
 		setVisited(startingPoint, true);
@@ -2190,7 +2135,7 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 		Point nextPoint = getNextUnvisitedVoxel(startingPoint);
 		
 		if (nextPoint == null)
-			return 0;
+			return ret;
 		
 		Point previousPoint = startingPoint;
 		
@@ -2204,6 +2149,9 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 			
 			// Add length
 			length += calculateDistance(previousPoint, nextPoint);
+			pointHistory.add(0,nextPoint);
+
+			length_ra += calculateDistance(pointHistory);
 			
 			// Mark as visited
 			setVisited(nextPoint, true);
@@ -2221,6 +2169,9 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 		{
 			// Add distance to last point
 			length += calculateDistance(previousPoint, nextPoint);
+			pointHistory.add(0,nextPoint);
+			length_ra += calculateDistance(pointHistory);
+
 		
 			// Mark last point as visited
 			setVisited(nextPoint, true);
@@ -2241,6 +2192,7 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 				// Add the length to the first point of the vertex (to prevent later from having
 				// euclidean distances larger than the actual distance)
 				length += calculateDistance(auxFinalVertex.getPoints().get(0), nextPoint);
+				length_ra += calculateDistance(auxFinalVertex.getPoints().get(0), nextPoint);
 				/*
 				int j = 0;
 				for(j = 0; j < this.junctionVertex[iTree].length; j++)
@@ -2261,8 +2213,36 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 			this.auxPoint = previousPoint;
 		
 		//IJ.log("finalPoint = (" + nextPoint.x + ", " + nextPoint.y + ", " + nextPoint.z + ")");
-		return length;
-	} // end visitBranch	
+		
+		// calculate average color (thickness) value, but only take the inner third of a branch.
+		// at both ends the color (thickness) is most likely affected by junctions.
+		
+
+		int size = pointHistory.size();
+		int start = (int)(size/3.0);
+		int end = (int)(2*size/3.0);
+		
+		for (int i = 0; i < size ;i++){
+			int value = getPixel(this.inputImage, pointHistory.get(i));
+			if (value < 0){
+				value += 256;
+			}
+			color += value;
+			if (i>=start && i<end){
+				color3rd += value;
+			}
+		}
+		
+		color /= size; 
+		color3rd /= (end-start);
+		
+		ret[0] = length;
+		ret[1] = color3rd;
+		ret[2] = color;
+		ret[3] = length_ra;
+		
+		return ret;
+	} // end visitBranch
 	
 	// -----------------------------------------------------------------------
 	/**
@@ -2301,7 +2281,34 @@ public class AnalyzeSkeleton_ implements PlugInFilter, DialogListener
 				          + Math.pow( (point1.y - point2.y) * this.imRef.getCalibration().pixelHeight, 2)
 				          + Math.pow( (point1.z - point2.z) * this.imRef.getCalibration().pixelDepth, 2));
 	}
-
+	
+	// -----------------------------------------------------------------------
+		/**
+		 * Calculate linear corrected distance between two points in 3D.
+		 * Uses the PointHistory of a branch and its 5 last points.
+		 * 
+		 * @param Points - the last visited Points (most recent has Index 0)
+		 * @return linear corrected distance between the last two Points (in the corresponding units)
+		 */
+	private double calculateDistance(List<Point> Points)
+	{
+		int indexOfLast = Points.size()-1;
+		
+		//no Distance to be calculated here...
+		if (indexOfLast < 1) return 0;
+		
+		// Point Of Interest
+		int poi = 5;
+		
+		//poi is indexOflast if List is shorter than 5
+		if (indexOfLast < 5){
+			poi = indexOfLast;
+		}
+		return Math.sqrt(  Math.pow( (Points.get(poi).x - Points.get(0).x) * this.imRef.getCalibration().pixelWidth, 2) 
+		          + Math.pow( (Points.get(poi).y - Points.get(0).y) * this.imRef.getCalibration().pixelHeight, 2)
+		          + Math.pow( (Points.get(poi).z - Points.get(0).z) * this.imRef.getCalibration().pixelDepth, 2))/poi;
+	}
+	
 	// -----------------------------------------------------------------------
 	/**
 	 * Calculate number of junction skipping neighbor junction voxels

--- a/src/main/java/sc/fiji/analyzeSkeleton/AnalyzeSkeleton_.java
+++ b/src/main/java/sc/fiji/analyzeSkeleton/AnalyzeSkeleton_.java
@@ -1,10 +1,7 @@
 package sc.fiji.analyzeSkeleton;
 
-import ij.IJ;
-import ij.ImagePlus;
-import ij.ImageStack;
-import ij.Prefs;
-import ij.WindowManager;
+import ij.*;
+
 import ij.gui.DialogListener;
 import ij.gui.GenericDialog;
 import ij.gui.Roi;

--- a/src/main/java/sc/fiji/analyzeSkeleton/Edge.java
+++ b/src/main/java/sc/fiji/analyzeSkeleton/Edge.java
@@ -44,6 +44,13 @@ public class Edge
 	private ArrayList <Point> slabs = null;
 	/** length of the edge */
 	private double length = 0;
+	/** average color of edge */
+	private double color = 0;
+	/** average color of inner third of  edge */
+	private double color3rd = 0;
+	/** length calculated by running average ovr 5 Pixel */
+	private double length_ra = 0;
+	
 
 	/**
 	 * Create an edge of specific vertices and list of slab voxels.
@@ -63,6 +70,36 @@ public class Edge
 		this.slabs = slabs;
 		this.length = length;
 	}
+
+	/**
+	 * Create an edge of specific vertices and list of slab voxels.
+	 * @param v1 first vertex
+	 * @param v2 second vertex
+	 * @param slabs list of slab voxels
+	 * @param length calibrated edge length
+	 * @param color3rd average color value of the inner third
+	 * @param color average color value
+	 * @param length_ra calibrated edge length calculated with running average ofer 5 Pixel
+	 */
+	public Edge(
+			Vertex v1, 
+			Vertex v2, 
+			ArrayList<Point> slabs,
+			double length,
+			double color3rd,
+			double color,
+			double length_ra)
+	{
+		this.v1 = v1;
+		this.v2 = v2;
+		this.slabs = slabs;
+		this.length = length;
+		this.color = color;
+		this.color3rd = color3rd;
+		this.length_ra = length_ra;
+		
+	}
+	
 	/**
 	 * Get first vertex. 
 	 * @return first vertex of the edge
@@ -134,6 +171,38 @@ public class Edge
 	public double getLength()
 	{
 		return this.length;
+	}
+	
+	/**
+	 * Get edge length_ra (running average)
+	 * @return calibrated edge length (running average)
+	 */
+	public double getLength_ra()
+	{
+		return this.length_ra;
+	}
+	
+	
+	public void setColor(double color)
+	{
+		this.color = color;
+	}
+	
+	
+	public double getColor()
+	{
+		return this.color;
+	}
+	
+	public void setColor3rd(double color)
+	{
+		this.color3rd = color;
+	}
+	
+	
+	public double getColor3rd()
+	{
+		return this.color3rd;
 	}
 	
 }// end class Edge


### PR DESCRIPTION
This is our  suggestion for better results regarding the length calculation of the branches.
For that we use a running average over 5 Pixel. Look at this example Image for clarity:
![analyzeskeleton_test](https://cloud.githubusercontent.com/assets/17739275/13642656/a39f1328-e61d-11e5-8def-e28da6bc7c96.png)

As this Skeleton was drawn by hand using GIMP, the Branches are straight lines and the actual length should be the same as the Euclidean Distance.
This is the Case for horizontal and vertical as well as 45° diagonal Lines. For slopes with ratio 1:2 or 2:1 it differs over 8% (see attached file. i.e. Branch 3: length/euc.dist = 482.073/445.394 = 1.082)

With our Method the resulting length is 446.023 which is only 0.14% too long.

Further additions to the Code were made to give the average colour value of an Branch (over the whole and only over the middle third). This was made because we encode properties of the original Image within our so called "colored Skeleton".

In my Version I deleted the deprecated Method visitSkeleton(ImageStack taggedImage)

[Branch-information.txt](https://github.com/fiji/AnalyzeSkeleton/files/165595/Branch-information.txt)

